### PR TITLE
Add an env to control `--delete` behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) to sync a directory (either from your repository or generated during your workflow) with a remote DigitalOcean space.
 
-**Performing this action deletes any files in the bucket that are *not* present in the source directory.** Working on making this optional in the next release!
-
 ## Usage
 
 ### `workflow.yml` Example
@@ -39,6 +37,7 @@ jobs:
 | ------------- | ------------- | ------------- | ------------- |
 | `SOURCE_DIR` | The local directory you wish to sync/upload. For example, `./public`. | `env` | **Yes** |
 | `SPACE_REGION` | The region where you created your space in. For example, `fra1`. [Full list of regions here.](https://www.digitalocean.com/docs/platform/availability-matrix/) | `env` | **Yes** |
+| `DELETE` | If set to `true`, deletes any files in the bucket that are *not* present in the source directory. Default: `true`. | `env` | **No** |
 
 
 ### Required Secret Variables

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # GitHub Action to Sync DigitalOcean Space 🔄 
 
-> **⚠️ Note:** To use this action, you must have access to the [GitHub Actions](https://github.com/features/actions) feature. GitHub Actions are currently only available in public beta. You can [apply for the GitHub Actions beta here](https://github.com/features/actions/signup/).
-
 This simple action uses the [vanilla AWS CLI](https://docs.aws.amazon.com/cli/index.html) to sync a directory (either from your repository or generated during your workflow) with a remote DigitalOcean space.
 
 ## Usage

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,13 @@ echo "[default]
 aws_access_key_id = ${SPACE_ACCESS_KEY_ID}
 aws_secret_access_key = ${SPACE_SECRET_ACCESS_KEY}" > ~/.aws/credentials
 
+if test "${DELETE}" == "true" || test -z "${DELETE}"; then
+	DELETE_ARG="--delete"
+fi
+
 aws s3 sync ${SOURCE_DIR} s3://${SPACE_NAME} \
             --follow-symlinks \
-            --delete \
+            ${DELETE_ARG} \
             --endpoint https://${SPACE_REGION}.digitaloceanspaces.com $*
 
 rm -rf ~/.aws


### PR DESCRIPTION
This PR mainly adds the needed option to disable `--delete` arg from the underlying `aws` command.